### PR TITLE
Javafx response 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ Thumbs.db
 
 org.jcryptool.product/plugin_customization.ini
 .settings/
-.project

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>core</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/org.jcryptool.analysis.friedman/.project
+++ b/org.jcryptool.analysis.friedman/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.jcryptool.analysis.friedman</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/FriedmanGraphUI.java
+++ b/org.jcryptool.analysis.friedman/src/org/jcryptool/analysis/friedman/ui/FriedmanGraphUI.java
@@ -159,23 +159,23 @@ public class FriedmanGraphUI extends org.eclipse.swt.widgets.Composite implement
 			group1LData.grabExcessVerticalSpace = true;
 			group1.setLayoutData(group1LData);
 			group1.setText(Messages.FriedmanGraphUI_graph);
-//			{
-//			final FXCanvas fxCanvas = new FXCanvas(group1, SWT.NONE) {
-//		            public org.eclipse.swt.graphics.Point computeSize(int wHint, int hHint, boolean changed) {
-//		                getScene().getWindow().sizeToScene();
-//		                int width = (int) getScene().getWidth();
-//		                int height = (int) getScene().getHeight();
-//		                return new org.eclipse.swt.graphics.Point(width, height);
-//		            }
-//		        };
-//		        //javafx.scene.Group group = new javafx.scene.Group();
-//		        /* Create a JavaFX button */
-//		        //final javafx.scene.control.Button jfxButton = new javafx.scene.control.Button("JFX Button");
-//		        /* Assign the CSS ID ipad-dark-grey */
-//		        //jfxButton.setId("ipad-dark-grey");
-//		        /* Add the button as a child of the Group node */
-//		        //group.getChildren().add(jfxButton);
-//			}
+			{
+			final FXCanvas fxCanvas = new FXCanvas(group1, SWT.NONE) {
+		            public org.eclipse.swt.graphics.Point computeSize(int wHint, int hHint, boolean changed) {
+		                getScene().getWindow().sizeToScene();
+		                int width = (int) getScene().getWidth();
+		                int height = (int) getScene().getHeight();
+		                return new org.eclipse.swt.graphics.Point(width, height);
+		            }
+		        };
+		        javafx.scene.Group group = new javafx.scene.Group();
+		        /* Create a JavaFX button */
+		        final javafx.scene.control.Button jfxButton = new javafx.scene.control.Button("JFX Button");
+		        /* Assign the CSS ID ipad-dark-grey */
+		        jfxButton.setId("ipad-dark-grey");
+		        /* Add the button as a child of the Group node */
+		        group.getChildren().add(jfxButton);
+			}
 			{
 				myGraph = new CustomFriedmanCanvas(group1, SWT.DOUBLE_BUFFERED);
 

--- a/org.jcryptool.product/jcryptool.product
+++ b/org.jcryptool.product/jcryptool.product
@@ -18,6 +18,8 @@
       </programArgs>
       <vmArgs>-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog
 --add-modules=ALL-SYSTEM
+-Dorg.osgi.framework.bundle.parent=ext
+-Dosgi.framework.extensions=org.eclipse.fx.osgi parameters
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>

--- a/org.jcryptool.target/org.jcryptool.target.target
+++ b/org.jcryptool.target/org.jcryptool.target.target
@@ -14,9 +14,9 @@
         <unit id="org.eclipse.babel.nls_eclipse_de.feature.group" version="4.8.0.v20180815020001"/>
         <repository location="http://download.eclipse.org/technology/babel/update-site/R0.16.0/photon/"/>
     </location>
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
-		<unit id="org.eclipse.fx.target.feature.feature.group" version="3.3.0.201809010600"/>
-		<repository location="http://download.eclipse.org/efxclipse/runtime-released/3.4.0/site/"/>
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<unit id="org.eclipse.fx.target.rcp.feature.feature.group" version="3.5.0.201812180700"/>
+		<repository location="http://download.eclipse.org/efxclipse/runtime-nightly/site"/>
 	</location>
 </locations>
 <launcherArgs>


### PR DESCRIPTION
I think, the javafx binaries are now pulled in. In any case we should sync up. Please try to run the friedman plugin in `org.jcryptool.analysis.friedman`. Please review the diff of the PR as it is quite compact to see where I made changes.

I currently get different errors than when I started out, and the error seems to be a JNI binary one, suggesting, that now it tries to load the javafx native components. Are you getting anything like this?

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f175ad512b7, pid=793, tid=0x00007f180b041700
#
```

In the error search I noticed that there have been quite a few changes in the e(fx)clipse packages. They tried to sort it out but produced old forum threads that do not reflect the current state of doing things.

Most importantly, you hear often that you have to use for Java VM arguments:
1) `-Dosgi.framework.extensions=org.eclipse.fx.osgi`
and also that you need
2) `-Dorg.osgi.framework.bundle.parent=ext`
Sometimes, a person says, 1) is not necessary, sometimes, 2) is not necessary. It changed with e(fx)clipse version 2.0, but not everywhere :slightly_frowning_face: The best way seems to be to include both.

Regarding the launch parameters to the VM, the most useful thread is:

[1] https://www.eclipse.org/forums/index.php/t/1087013/ and see post https://www.eclipse.org/forums/index.php?t=msg&th=1087013&goto=1768852&#msg_1768852 and beyond for clarifications on that matter. Post https://www.eclipse.org/forums/index.php?t=msg&th=1087013&goto=1770753&#msg_1770753 is a happy user who made it after those clarifications. I followed these steps. Post https://www.eclipse.org/forums/index.php?t=msg&th=1087013&goto=1770765&#msg_1770765 points to the tutorial which is supposed to help most with this use case; please also read that when having questions about how to proceed best on further errors.

Another useful thread is: https://www.eclipse.org/forums/index.php/t/1087038/

In investigating this further, you could consider opening a Thread in these eclipse forums and pinging the user "Thomas Schindl" about the issue, as he seems to be one of the more knowledgeable folk in these discussions. I think he may even maintain part of e(fx)clipse. You could point him to this string of PR's for code / target platform parts.

Note, that you should make sure to set the VM arguments also in the RunConfiguration (Green "Play" button to launch JCT) and check whether org.eclipse.fx.osgi is included in the plugin/feature list. I have already included it in the product configuration, but from user's comments, this seems to be necessary still. Screenshot:
![image](https://user-images.githubusercontent.com/982379/50173316-53f12100-02f7-11e9-9457-70de0aed7712.png)
